### PR TITLE
fix: the number of program arguments check is incorrect

### DIFF
--- a/src/main/kotlin/org/pkl/k8s/templates/Main.kt
+++ b/src/main/kotlin/org/pkl/k8s/templates/Main.kt
@@ -56,7 +56,7 @@ private val licenseHeader = """
   """.trimIndent()
 
 fun main(args: Array<String>) {
-  require(args.size > 3) {
+  require(args.size > 2) {
     throw ConversionException("Usage: org.pkl.k8s.templates.MainKt outputPath buildDir openApiSpecPath...")
   }
 


### PR DESCRIPTION
This is a small bug that can occur when there is a single K8S Open-API spec file.