### PR TITLE
Add support for Kubernetes 1.30

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,8 @@ val k8sVersions = listOf(
   "v1.26.12",
   "v1.27.9",
   "v1.28.5",
-  "v1.29.0"
+  "v1.29.0",
+  "v1.30.0"
 )
 
 val isCiBuild = System.getenv("CI") != null

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
   jvmToolchain(17)
 }
 
-val pklPackageVersion = "1.0.1"
+val pklPackageVersion = "1.1.0"
 
 val k8sVersions = listOf(
   "v1.19.6",

--- a/generated-package/api/admissionregistration/v1/MatchResources.pkl
+++ b/generated-package/api/admissionregistration/v1/MatchResources.pkl
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// MatchResources decides whether to run the admission control policy on an object based on whether it meets the match criteria.
+///
+/// The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+module k8s.api.admissionregistration.v1.MatchResources
+
+extends ".../K8sObject.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/LabelSelector.pkl"
+
+/// matchPolicy defines how the "MatchResources" list is used to match incoming requests.
+///
+/// Allowed values are "Exact" or "Equivalent".
+/// 
+/// - Exact: match a request only if it exactly matches a specified rule.
+/// For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the ValidatingAdmissionPolicy.
+/// 
+/// - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version.
+/// For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
+/// 
+/// Defaults to "Equivalent"
+matchPolicy: String?
+
+/// ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches.
+///
+/// The policy cares about an operation if it matches _any_ Rule.
+resourceRules: Listing<NamedRuleWithOperations>?
+
+/// ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about.
+///
+/// The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+excludeResourceRules: Listing<NamedRuleWithOperations>?
+
+/// NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector.
+///
+/// If the object itself is a namespace, the matching is performed on object.metadata.labels.
+/// If the object is another cluster scoped resource, it never skips the policy.
+/// 
+/// For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+///   "matchExpressions": [
+///     {
+///       "key": "runlevel",
+///       "operator": "NotIn",
+///       "values": [
+///         "0",
+///         "1"
+///       ]
+///     }
+///   ]
+/// }
+/// 
+/// If instead you want to only run the policy on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+///   "matchExpressions": [
+///     {
+///       "key": "environment",
+///       "operator": "In",
+///       "values": [
+///         "prod",
+///         "staging"
+///       ]
+///     }
+///   ]
+/// }
+/// 
+/// See <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/> for more examples of label selectors.
+/// 
+/// Default to the empty LabelSelector, which matches everything.
+namespaceSelector: LabelSelector?
+
+/// ObjectSelector decides whether to run the validation based on if the object has matching labels.
+///
+/// objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector.
+/// A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match.
+/// Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels.
+/// Default to the empty LabelSelector, which matches everything.
+objectSelector: LabelSelector?
+
+/// NamedRuleWithOperations is a tuple of Operations and Resources with ResourceNames.
+class NamedRuleWithOperations {
+  /// ResourceNames is an optional white list of names that the rule applies to.
+  ///
+  /// An empty set means that everything is allowed.
+  resourceNames: Listing<String>?
+
+  /// Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added.
+  ///
+  /// If '*' is present, the length of the slice must be one.
+  /// Required.
+  operations: Listing<String>
+
+  /// APIVersions is the API versions the resources belong to.
+  ///
+  /// '*' is all versions.
+  /// If '*' is present, the length of the slice must be one.
+  /// Required.
+  apiVersions: Listing<String>
+
+  /// scope specifies the scope of this rule.
+  ///
+  /// Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule.
+  /// Namespace API objects are cluster-scoped.
+  /// "Namespaced" means that only namespaced resources will match this rule.
+  /// "*" means that there are no scope restrictions.
+  /// Subresources match the scope of their parent resource.
+  /// Default is "*".
+  scope: String?
+
+  /// Resources is a list of resources this rule applies to.
+  ///
+  /// 
+  /// For example: 'pods' means pods.
+  /// 'pods/log' means the log subresource of pods.
+  /// '*' means all resources, but not subresources.
+  /// 'pods/*' means all subresources of pods.
+  /// '*/scale' means all scale subresources.
+  /// '*/*' means all resources and their subresources.
+  /// 
+  /// If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+  /// 
+  /// Depending on the enclosing object, subresources might not be allowed.
+  /// Required.
+  resources: Listing<String>
+
+  /// APIGroups is the API groups the resources belong to.
+  ///
+  /// '*' is all groups.
+  /// If '*' is present, the length of the slice must be one.
+  /// Required.
+  apiGroups: Listing<String>
+}
+

--- a/generated-package/api/admissionregistration/v1/MutatingWebhookConfiguration.pkl
+++ b/generated-package/api/admissionregistration/v1/MutatingWebhookConfiguration.pkl
@@ -150,8 +150,6 @@ class MutatingWebhook {
   /// If any matchCondition evaluates to an error (but none are FALSE):
   ///      - If failurePolicy=Fail, reject the request
   ///      - If failurePolicy=Ignore, the error is ignored and the webhook is skipped
-  /// 
-  /// This is a beta feature and managed by the AdmissionWebhookMatchConditions feature gate.
   @K8sVersion { introducedIn = "1.27" }
   matchConditions: Listing<MatchCondition>?
 

--- a/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicy.pkl
+++ b/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicy.pkl
@@ -1,0 +1,283 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.admissionregistration.v1.ValidatingAdmissionPolicy
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+import ".../api/admissionregistration/v1/MatchCondition.pkl"
+import ".../api/admissionregistration/v1/MatchResources.pkl"
+import ".../apimachinery/pkg/apis/meta/v1/Condition.pkl"
+
+fixed apiVersion: "admissionregistration.k8s.io/v1"
+
+fixed kind: "ValidatingAdmissionPolicy"
+
+/// Standard object metadata; More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.>
+metadata: ObjectMeta?
+
+/// Specification of the desired behavior of the ValidatingAdmissionPolicy.
+spec: ValidatingAdmissionPolicySpec?
+
+/// The status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy behaves in the expected way.
+///
+/// Populated by the system.
+/// Read-only.
+status: ValidatingAdmissionPolicyStatus?
+
+/// ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.
+class ValidatingAdmissionPolicySpec {
+  /// Variables contain definitions of variables that can be used in composition of other expressions.
+  ///
+  /// Each variable is defined as a named CEL expression.
+  /// The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+  /// 
+  /// The expression of a variable can refer to other variables defined earlier in the list but not those after.
+  /// Thus, Variables must be sorted by the order of first appearance and acyclic.
+  variables: Listing<Variable>?
+
+  /// ParamKind specifies the kind of resources used to parameterize this policy.
+  ///
+  /// If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions.
+  /// If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied.
+  /// If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null.
+  paramKind: ParamKind?
+
+  /// auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.
+  ///
+  /// validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.
+  auditAnnotations: Listing<AuditAnnotation>?
+
+  /// MatchConditions is a list of conditions that must be met for a request to be validated.
+  ///
+  /// Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector.
+  /// An empty list of matchConditions matches all requests.
+  /// There are a maximum of 64 match conditions allowed.
+  /// 
+  /// If a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.
+  /// 
+  /// The exact matching logic is (in order):
+  ///   1.
+  /// If ANY matchCondition evaluates to FALSE, the policy is skipped.
+  ///   2.
+  /// If ALL matchConditions evaluate to TRUE, the policy is evaluated.
+  ///   3.
+  /// If any matchCondition evaluates to an error (but none are FALSE):
+  ///      - If failurePolicy=Fail, reject the request
+  ///      - If failurePolicy=Ignore, the policy is skipped
+  matchConditions: Listing<MatchCondition>?
+
+  /// MatchConstraints specifies what resources this policy is designed to validate.
+  ///
+  /// The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+  /// However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding.
+  /// Required.
+  matchConstraints: MatchResources
+
+  /// Validations contain CEL expressions which is used to apply the validation.
+  ///
+  /// Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.
+  validations: Listing<Validation>?
+
+  /// failurePolicy defines how to handle failures for the admission policy.
+  ///
+  /// Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.
+  /// 
+  /// A policy is invalid if spec.paramKind refers to a non-existent Kind.
+  /// A binding is invalid if spec.paramRef.name refers to a non-existent resource.
+  /// 
+  /// failurePolicy does not define how validations that evaluate to false are handled.
+  /// 
+  /// When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
+  /// 
+  /// Allowed values are Ignore or Fail.
+  /// Defaults to Fail.
+  failurePolicy: String?
+}
+
+/// Variable is the definition of a variable that is used for composition.
+///
+/// A variable is defined as a named expression.
+class Variable {
+  /// Expression is the expression that will be evaluated as the value of the variable.
+  ///
+  /// The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+  expression: String
+
+  /// Name is the name of the variable.
+  ///
+  /// The name must be a valid CEL identifier and unique among all variables.
+  /// The variable can be accessed in other expressions through `variables` For example, if name is "foo", the variable will be available as `variables.foo`
+  name: String
+}
+
+/// ParamKind is a tuple of Group Kind and Version.
+class ParamKind {
+  /// APIVersion is the API group version the resources belong to.
+  ///
+  /// In format of "group/version".
+  /// Required.
+  apiVersion: String
+
+  /// Kind is the API kind the resources belong to.
+  ///
+  /// Required.
+  kind: String
+}
+
+/// AuditAnnotation describes how to produce an audit annotation for an API request.
+class AuditAnnotation {
+  /// valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value.
+  ///
+  /// The expression must evaluate to either a string or null value.
+  /// If the expression evaluates to a string, the audit annotation is included with the string value.
+  /// If the expression evaluates to null or empty string the audit annotation will be omitted.
+  /// The valueExpression may be no longer than 5kb in length.
+  /// If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.
+  /// 
+  /// If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding.
+  /// All unique values produced by the valueExpressions will be joined together in a comma-separated list.
+  /// 
+  /// Required.
+  valueExpression: String
+
+  /// key specifies the audit annotation key.
+  ///
+  /// The audit annotation keys of a ValidatingAdmissionPolicy must be unique.
+  /// The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+  /// 
+  /// The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: "{ValidatingAdmissionPolicy name}/{key}".
+  /// 
+  /// If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical.
+  /// In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.
+  /// 
+  /// Required.
+  key: String
+}
+
+/// Validation specifies the CEL expression which is used to apply the validation.
+class Validation {
+  /// Reason represents a machine-readable description of why this validation failed.
+  ///
+  /// If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client.
+  /// The currently supported reasons are: "Unauthorized", "Forbidden", "Invalid", "RequestEntityTooLarge".
+  /// If not set, StatusReasonInvalid is used in the response to the client.
+  reason: String?
+
+  /// Expression represents the expression which will be evaluated by CEL.
+  ///
+  /// ref: <https://github.com/google/cel-spec> CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:
+  /// 
+  /// - 'object' - The object from the incoming request.
+  /// The value is null for DELETE requests.
+  /// - 'oldObject' - The existing object.
+  /// The value is null for CREATE requests.
+  /// - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).
+  /// - 'params' - Parameter resource referred to by the policy binding being evaluated.
+  /// Only populated if the policy has a ParamKind.
+  /// - 'namespaceObject' - The namespace object that the incoming object belongs to.
+  /// The value is null for cluster-scoped resources.
+  /// - 'variables' - Map of composited variables, from its name to its lazily evaluated value.
+  ///   For example, a variable named 'foo' can be accessed as 'variables.foo'.
+  /// - 'authorizer' - A CEL Authorizer.
+  /// May be used to perform authorization checks for the principal (user or service account) of the request.
+  ///   See <https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz>
+  /// - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+  ///   request resource.
+  /// 
+  /// The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object.
+  /// No other metadata properties are accessible.
+  /// 
+  /// Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.
+  /// Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'.
+  /// The keywords are:
+  /// 	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+  /// 	  "import", "let", "loop", "package", "namespace", "return".
+  /// Examples:
+  ///   - Expression accessing a property named "namespace": {"Expression": "object.__namespace__ > 0"}
+  ///   - Expression accessing a property named "x-prop": {"Expression": "object.x__dash__prop > 0"}
+  ///   - Expression accessing a property named "redact__d": {"Expression": "object.redact__underscores__d > 0"}
+  /// 
+  /// Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].
+  /// Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+  ///   - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+  ///     non-intersecting elements in `Y` are appended, retaining their partial order.
+  ///   - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+  ///     are overwritten by values in `Y` when the key sets of `X` and `Y` intersect.
+  /// Elements in `Y` with
+  ///     non-intersecting keys are appended, retaining their partial order.
+  /// Required.
+  expression: String
+
+  /// messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.
+  ///
+  /// Since messageExpression is used as a failure message, it must evaluate to a string.
+  /// If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails.
+  /// If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset.
+  /// If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged.
+  /// messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'.
+  /// Example: "object.x must be less than max ("+string(params.max)+")"
+  messageExpression: String?
+
+  /// Message represents the message displayed when validation fails.
+  ///
+  /// The message is required if the Expression contains line breaks.
+  /// The message must not contain line breaks.
+  /// If unset, the message is "failed rule: {Rule}".
+  /// e.g. "must be a URL with the host matching spec.host" If the Expression contains line breaks.
+  /// Message is required.
+  /// The message must not contain line breaks.
+  /// If unset, the message is "failed Expression: {Expression}".
+  message: String?
+}
+
+/// ValidatingAdmissionPolicyStatus represents the status of an admission validation policy.
+class ValidatingAdmissionPolicyStatus {
+  /// The results of type checking for each expression.
+  ///
+  /// Presence of this field indicates the completion of the type checking.
+  typeChecking: TypeChecking?
+
+  /// The conditions represent the latest available observations of a policy's current state.
+  conditions: Listing<Condition>?
+
+  /// The generation observed by the controller.
+  observedGeneration: Int?
+}
+
+/// TypeChecking contains results of type checking the expressions in the ValidatingAdmissionPolicy
+class TypeChecking {
+  /// The type checking warnings for each expression.
+  expressionWarnings: Listing<ExpressionWarning>?
+}
+
+/// ExpressionWarning is a warning information that targets a specific expression.
+class ExpressionWarning {
+  /// The path to the field that refers the expression.
+  ///
+  /// For example, the reference to the expression of the first item of validations is "spec.validations[0].expression"
+  fieldRef: String
+
+  /// The content of type checking information in a human-readable form.
+  ///
+  /// Each line of the warning contains the type that the expression is checked against, followed by the type check error from the compiler.
+  warning: String
+}
+

--- a/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicyBinding.pkl
+++ b/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicyBinding.pkl
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources.
+///
+/// ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
+/// 
+/// For a given admission request, each binding will cause its policy to be evaluated N times, where N is 1 for policies/bindings that don't use params, otherwise N is the number of parameters selected by the binding.
+/// 
+/// The CEL expressions of a policy must have a computed CEL cost below the maximum CEL budget.
+/// Each evaluation of the policy is given an independent CEL cost budget.
+/// Adding/removing policies, bindings, or params can not affect whether a given (policy, binding, param) combination is within its own CEL budget.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBinding
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+import ".../apimachinery/pkg/apis/meta/v1/LabelSelector.pkl"
+import ".../api/admissionregistration/v1/MatchResources.pkl"
+
+fixed apiVersion: "admissionregistration.k8s.io/v1"
+
+fixed kind: "ValidatingAdmissionPolicyBinding"
+
+/// Standard object metadata; More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.>
+metadata: ObjectMeta?
+
+/// Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+spec: ValidatingAdmissionPolicyBindingSpec?
+
+/// ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.
+class ValidatingAdmissionPolicyBindingSpec {
+  /// paramRef specifies the parameter resource used to configure the admission control policy.
+  ///
+  /// It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy.
+  /// If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied.
+  /// If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.
+  paramRef: ParamRef?
+
+  /// PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to.
+  ///
+  /// If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.
+  policyName: String
+
+  /// MatchResources declares what resources match this binding and will be validated by it.
+  ///
+  /// Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this.
+  /// If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching.
+  /// If a resource is matched by the other fields of this object, it will be validated.
+  /// Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required.
+  matchResources: MatchResources?
+
+  /// validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced.
+  ///
+  /// If a validation evaluates to false it is always enforced according to these actions.
+  /// 
+  /// Failures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored.
+  /// This includes compilation errors, runtime errors and misconfigurations of the policy.
+  /// 
+  /// validationActions is declared as a set of action values.
+  /// Order does not matter.
+  /// validationActions may not contain duplicates of the same action.
+  /// 
+  /// The supported actions values are:
+  /// 
+  /// "Deny" specifies that a validation failure results in a denied request.
+  /// 
+  /// "Warn" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299.
+  /// Warnings can be sent both for allowed or denied admission responses.
+  /// 
+  /// "Audit" specifies that a validation failure is included in the published audit event for the request.
+  /// The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `"validation.policy.admission.k8s.io/validation_failure": "[{"message": "Invalid value", {"policy": "policy.example.com", {"binding": "policybinding.example.com", {"expressionIndex": "1", {"validationActions": ["Audit"]}]"`
+  /// 
+  /// Clients should expect to handle additional values by ignoring any values not recognized.
+  /// 
+  /// "Deny" and "Warn" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.
+  /// 
+  /// Required.
+  validationActions: Listing<String>
+}
+
+/// ParamRef describes how to locate the params to be used as input to expressions of rules applied by a policy binding.
+class ParamRef {
+  /// name is the name of the resource being referenced.
+  ///
+  /// 
+  /// One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties.
+  /// If one is set, the other must be unset.
+  /// 
+  /// A single parameter used for all admission requests can be configured by setting the `name` field, leaving `selector` blank, and setting namespace if `paramKind` is namespace-scoped.
+  name: String?
+
+  /// namespace is the namespace of the referenced resource.
+  ///
+  /// Allows limiting the search for params to a specific namespace.
+  /// Applies to both `name` and `selector` fields.
+  /// 
+  /// A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty.
+  /// 
+  /// - If `paramKind` is cluster-scoped, this field MUST be unset.
+  /// Setting this field results in a configuration error.
+  /// 
+  /// - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset.
+  /// Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.
+  namespace: String?
+
+  /// selector can be used to match multiple param objects based on their labels.
+  ///
+  /// Supply selector: {} to match all resources of the ParamKind.
+  /// 
+  /// If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.
+  /// 
+  /// One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties.
+  /// If one is set, the other must be unset.
+  selector: LabelSelector?
+
+  /// `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding.
+  ///
+  /// If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding.
+  /// If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
+  /// 
+  /// Allowed values are `Allow` or `Deny`
+  /// 
+  /// Required
+  parameterNotFoundAction: String?
+}
+

--- a/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicyBindingList.pkl
+++ b/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicyBindingList.pkl
@@ -14,26 +14,25 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-/// ResourceClaimSpec defines how a resource is to be allocated.
-@K8sVersion { introducedIn = "1.27" }
+/// ValidatingAdmissionPolicyBindingList is a list of ValidatingAdmissionPolicyBinding.
+@K8sVersion { introducedIn = "1.30" }
 @ModuleInfo { minPklVersion = "0.25.0" }
-module k8s.api.resource.v1alpha2.ResourceClaimSpec
+open module k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyBindingList
 
-extends ".../K8sObject.pkl"
+extends ".../K8sResource.pkl"
 
-import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl"
+import ".../apimachinery/pkg/apis/meta/v1/ListMeta.pkl"
+import ".../api/admissionregistration/v1/ValidatingAdmissionPolicyBinding.pkl"
 
-/// Allocation can start immediately or when a Pod wants to use the resource.
+fixed apiVersion: "admissionregistration.k8s.io/v1"
+
+fixed kind: "ValidatingAdmissionPolicyBindingList"
+
+/// Standard list metadata.
 ///
-/// "WaitForFirstConsumer" is the default.
-allocationMode: String?
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds>
+metadata: ListMeta?
 
-/// ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
-resourceClassName: String
-
-/// ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
-///
-/// 
-/// The object must be in the same namespace as the ResourceClaim.
-parametersRef: ResourceClaimParametersReference?
+/// List of PolicyBinding.
+items: Listing<ValidatingAdmissionPolicyBinding>?
 

--- a/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicyList.pkl
+++ b/generated-package/api/admissionregistration/v1/ValidatingAdmissionPolicyList.pkl
@@ -14,26 +14,25 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-/// ResourceClaimSpec defines how a resource is to be allocated.
-@K8sVersion { introducedIn = "1.27" }
+/// ValidatingAdmissionPolicyList is a list of ValidatingAdmissionPolicy.
+@K8sVersion { introducedIn = "1.30" }
 @ModuleInfo { minPklVersion = "0.25.0" }
-module k8s.api.resource.v1alpha2.ResourceClaimSpec
+open module k8s.api.admissionregistration.v1.ValidatingAdmissionPolicyList
 
-extends ".../K8sObject.pkl"
+extends ".../K8sResource.pkl"
 
-import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl"
+import ".../apimachinery/pkg/apis/meta/v1/ListMeta.pkl"
+import ".../api/admissionregistration/v1/ValidatingAdmissionPolicy.pkl"
 
-/// Allocation can start immediately or when a Pod wants to use the resource.
+fixed apiVersion: "admissionregistration.k8s.io/v1"
+
+fixed kind: "ValidatingAdmissionPolicyList"
+
+/// Standard list metadata.
 ///
-/// "WaitForFirstConsumer" is the default.
-allocationMode: String?
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds>
+metadata: ListMeta?
 
-/// ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
-resourceClassName: String
-
-/// ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
-///
-/// 
-/// The object must be in the same namespace as the ResourceClaim.
-parametersRef: ResourceClaimParametersReference?
+/// List of ValidatingAdmissionPolicy.
+items: Listing<ValidatingAdmissionPolicy>?
 

--- a/generated-package/api/admissionregistration/v1/ValidatingWebhookConfiguration.pkl
+++ b/generated-package/api/admissionregistration/v1/ValidatingWebhookConfiguration.pkl
@@ -133,8 +133,6 @@ class ValidatingWebhook {
   /// If any matchCondition evaluates to an error (but none are FALSE):
   ///      - If failurePolicy=Fail, reject the request
   ///      - If failurePolicy=Ignore, the error is ignored and the webhook is skipped
-  /// 
-  /// This is a beta feature and managed by the AdmissionWebhookMatchConditions feature gate.
   @K8sVersion { introducedIn = "1.27" }
   matchConditions: Listing<MatchCondition>?
 

--- a/generated-package/api/apiserverinternal/v1alpha1/StorageVersion.pkl
+++ b/generated-package/api/apiserverinternal/v1alpha1/StorageVersion.pkl
@@ -66,7 +66,7 @@ class StorageVersionCondition {
   lastTransitionTime: Time?
 
   /// A human readable message indicating details about the transition.
-  message: String?
+  message: String
 
   /// Type of the condition.
   type: String

--- a/generated-package/api/batch/v1/Job.pkl
+++ b/generated-package/api/batch/v1/Job.pkl
@@ -48,7 +48,9 @@ class JobStatus {
   ///
   /// It is not guaranteed to be set in happens-before order across separate operations.
   /// It is represented in RFC3339 form and is in UTC.
-  /// The completion time is only set when the job finishes successfully.
+  /// The completion time is set when the job finishes successfully, and only then.
+  /// The value cannot be updated or removed.
+  /// The value indicates the same or later point in time as the startTime field.
   completionTime: Time?
 
   /// completedIndexes holds the completed indexes when .spec.completionMode = "Indexed" in a text format.
@@ -64,7 +66,9 @@ class JobStatus {
   @K8sVersion { introducedIn = "1.23" }
   ready: Int32?
 
-  /// The number of pending and running pods.
+  /// The number of pending and running pods which are not terminating (without a deletionTimestamp).
+  ///
+  /// The value is zero for finished jobs.
   active: Int32?
 
   /// Represents time when the job controller started processing a job.
@@ -72,6 +76,9 @@ class JobStatus {
   /// When a Job is created in the suspended state, this field is not set until the first time it is resumed.
   /// This field is reset every time a Job is resumed from suspension.
   /// It is represented in RFC3339 form and is in UTC.
+  /// 
+  /// Once set, the field can only be removed when the job is suspended.
+  /// The field cannot be modified while the job is unsuspended or finished.
   startTime: Time?
 
   /// The number of pods which are terminating (in phase Pending or Running and have a deletionTimestamp).
@@ -97,10 +104,13 @@ class JobStatus {
   ///     counter.
   /// 
   /// Old jobs might not be tracked using this field, in which case the field remains null.
+  /// The structure is empty for finished jobs.
   @K8sVersion { introducedIn = "1.22" }
   uncountedTerminatedPods: UncountedTerminatedPods?
 
   /// The number of pods which reached phase Failed.
+  ///
+  /// The value increases monotonically.
   failed: Int32?
 
   /// The latest available observations of an object's current state.
@@ -108,22 +118,33 @@ class JobStatus {
   /// When a Job fails, one of the conditions will have type "Failed" and status true.
   /// When a Job is suspended, one of the conditions will have type "Suspended" and status true; when the Job is resumed, the status of this condition will become false.
   /// When a Job is completed, one of the conditions will have type "Complete" and status true.
+  /// 
+  /// A job is considered finished when it is in a terminal condition, either "Complete" or "Failed".
+  /// A Job cannot have both the "Complete" and "Failed" conditions.
+  /// Additionally, it cannot be in the "Complete" and "FailureTarget" conditions.
+  /// The "Complete", "Failed" and "FailureTarget" conditions cannot be disabled.
+  /// 
   /// More info: <https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/>
   conditions: Listing<JobCondition>?
 
-  /// FailedIndexes holds the failed indexes when backoffLimitPerIndex=true.
+  /// FailedIndexes holds the failed indexes when spec.backoffLimitPerIndex is set.
   ///
   /// The indexes are represented in the text format analogous as for the `completedIndexes` field, ie.
   /// they are kept as decimal integers separated by commas.
   /// The numbers are listed in increasing order.
   /// Three or more consecutive numbers are compressed and represented by the first and last element of the series, separated by a hyphen.
   /// For example, if the failed indexes are 1, 3, 4, 5 and 7, they are represented as "1,3-5,7".
+  /// The set of failed indexes cannot overlap with the set of completed indexes.
+  /// 
   /// This field is beta-level.
   /// It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
   @K8sVersion { introducedIn = "1.28" }
   failedIndexes: String?
 
   /// The number of pods which reached phase Succeeded.
+  ///
+  /// The value increases monotonically for a given spec.
+  /// However, it may decrease in reaction to scale down of elastic indexed jobs.
   succeeded: Int32?
 }
 

--- a/generated-package/api/batch/v1/JobSpec.pkl
+++ b/generated-package/api/batch/v1/JobSpec.pkl
@@ -128,6 +128,18 @@ ttlSecondsAfterFinished: Int32?
 @K8sVersion { introducedIn = "1.28" }
 podReplacementPolicy: String?
 
+/// ManagedBy field indicates the controller that manages a Job.
+///
+/// The k8s Job controller reconciles jobs which don't have this field at all or the field value is the reserved string `kubernetes.io/job-controller`, but skips reconciling Jobs with a custom value for this field.
+/// The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first "/" must be a valid subdomain as defined by RFC 1123.
+/// All characters trailing the first "/" must be valid HTTP Path characters as defined by RFC 3986.
+/// The value cannot exceed 64 characters.
+/// 
+/// This field is alpha-level.
+/// The job controller accepts setting the field when the feature gate JobManagedBy is enabled (disabled by default).
+@K8sVersion { introducedIn = "1.30" }
+managedBy: String?
+
 /// A label query over pods that should match the pod count.
 ///
 /// Normally, the system sets this field for you.
@@ -150,6 +162,17 @@ maxFailedIndexes: Int32?
 ///
 /// If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
 activeDeadlineSeconds: Int?
+
+/// successPolicy specifies the policy when the Job can be declared as succeeded.
+///
+/// If empty, the default behavior applies - the Job is declared as succeeded only when the number of succeeded pods equals to the completions.
+/// When the field is specified, it must be immutable and works only for the Indexed Jobs.
+/// Once the Job meets the SuccessPolicy, the lingering pods are terminated.
+/// 
+/// This field  is alpha-level.
+/// To use this field, you must enable the `JobSuccessPolicy` feature gate (disabled by default).
+@K8sVersion { introducedIn = "1.30" }
+successPolicy: SuccessPolicy?
 
 /// PodFailurePolicy describes how failed pods influence the backoffLimit.
 class PodFailurePolicy {
@@ -244,5 +267,40 @@ class PodFailurePolicyOnPodConditionsPattern {
   /// To match a pod condition it is required that the specified status equals the pod condition status.
   /// Defaults to True.
   status: String
+}
+
+/// SuccessPolicy describes when a Job can be declared as succeeded based on the success of some indexes.
+class SuccessPolicy {
+  /// rules represents the list of alternative rules for the declaring the Jobs as successful before `.status.succeeded >= .spec.completions`.
+  ///
+  /// Once any of the rules are met, the "SucceededCriteriaMet" condition is added, and the lingering pods are removed.
+  /// The terminal state for such a Job has the "Complete" condition.
+  /// Additionally, these rules are evaluated in order; Once the Job meets one of the rules, other rules are ignored.
+  /// At most 20 elements are allowed.
+  rules: Listing<SuccessPolicyRule>
+}
+
+/// SuccessPolicyRule describes rule for declaring a Job as succeeded.
+///
+/// Each rule must have at least one of the "succeededIndexes" or "succeededCount" specified.
+class SuccessPolicyRule {
+  /// succeededCount specifies the minimal required size of the actual set of the succeeded indexes for the Job.
+  ///
+  /// When succeededCount is used along with succeededIndexes, the check is constrained only to the set of indexes specified by succeededIndexes.
+  /// For example, given that succeededIndexes is "1-4", succeededCount is "3", and completed indexes are "1", "3", and "5", the Job isn't declared as succeeded because only "1" and "3" indexes are considered in that rules.
+  /// When this field is null, this doesn't default to any value and is never evaluated at any time.
+  /// When specified it needs to be a positive integer.
+  succeededCount: Int32?
+
+  /// succeededIndexes specifies the set of indexes which need to be contained in the actual set of the succeeded indexes for the Job.
+  ///
+  /// The list of indexes must be within 0 to ".spec.completions-1" and must not contain duplicates.
+  /// At least one element is required.
+  /// The indexes are represented as intervals separated by commas.
+  /// The intervals can be a decimal integer or a pair of decimal integers separated by a hyphen.
+  /// The number are listed in represented by the first and last element of the series, separated by a hyphen.
+  /// For example, if the completed indexes are 1, 3, 4, 5 and 7, they are represented as "1,3-5,7".
+  /// When this field is null, this field doesn't default to any value and is never evaluated at any time.
+  succeededIndexes: String?
 }
 

--- a/generated-package/api/core/v1/AppArmorProfile.pkl
+++ b/generated-package/api/core/v1/AppArmorProfile.pkl
@@ -14,26 +14,25 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-/// ResourceClaimSpec defines how a resource is to be allocated.
-@K8sVersion { introducedIn = "1.27" }
+/// AppArmorProfile defines a pod or container's AppArmor settings.
+@K8sVersion { introducedIn = "1.30" }
 @ModuleInfo { minPklVersion = "0.25.0" }
-module k8s.api.resource.v1alpha2.ResourceClaimSpec
+module k8s.api.core.v1.AppArmorProfile
 
 extends ".../K8sObject.pkl"
 
-import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl"
-
-/// Allocation can start immediately or when a Pod wants to use the resource.
+/// localhostProfile indicates a profile loaded on the node that should be used.
 ///
-/// "WaitForFirstConsumer" is the default.
-allocationMode: String?
+/// The profile must be preconfigured on the node to work.
+/// Must match the loaded name of the profile.
+/// Must be set if and only if type is "Localhost".
+localhostProfile: String?
 
-/// ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
-resourceClassName: String
-
-/// ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
+/// type indicates which kind of AppArmor profile will be applied.
 ///
-/// 
-/// The object must be in the same namespace as the ResourceClaim.
-parametersRef: ResourceClaimParametersReference?
+/// Valid options are:
+///   Localhost - a profile pre-loaded on the node.
+///   RuntimeDefault - the container runtime's default profile.
+///   Unconfined - no AppArmor enforcement.
+type: String
 

--- a/generated-package/api/core/v1/Node.pkl
+++ b/generated-package/api/core/v1/Node.pkl
@@ -181,6 +181,10 @@ class NodeStatus {
   /// More info: <https://kubernetes.io/docs/concepts/nodes/node/#info>
   nodeInfo: NodeSystemInfo?
 
+  /// The available runtime handlers.
+  @K8sVersion { introducedIn = "1.30" }
+  runtimeHandlers: Listing<NodeRuntimeHandler>?
+
   /// Conditions is an array of current observed node conditions.
   ///
   /// More info: <https://kubernetes.io/docs/concepts/nodes/node/#condition>
@@ -267,6 +271,23 @@ class NodeSystemInfo {
 
   /// OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
   osImage: String
+}
+
+/// NodeRuntimeHandler is a set of runtime handler information.
+class NodeRuntimeHandler {
+  /// Supported features.
+  features: NodeRuntimeHandlerFeatures?
+
+  /// Runtime handler name.
+  ///
+  /// Empty for the default runtime handler.
+  name: String?
+}
+
+/// NodeRuntimeHandlerFeatures is a set of runtime features.
+class NodeRuntimeHandlerFeatures {
+  /// RecursiveReadOnlyMounts is set to true if the runtime handler supports RecursiveReadOnlyMounts.
+  recursiveReadOnlyMounts: Boolean?
 }
 
 /// NodeCondition contains condition information for a node.

--- a/generated-package/api/core/v1/PersistentVolume.pkl
+++ b/generated-package/api/core/v1/PersistentVolume.pkl
@@ -60,7 +60,7 @@ class PersistentVolumeStatus {
 
   /// lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions.
   ///
-  /// This is an alpha field and requires enabling PersistentVolumeLastPhaseTransitionTime feature.
+  /// This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
   @K8sVersion { introducedIn = "1.28" }
   lastPhaseTransitionTime: Time?
 

--- a/generated-package/api/core/v1/PersistentVolumeClaim.pkl
+++ b/generated-package/api/core/v1/PersistentVolumeClaim.pkl
@@ -120,7 +120,7 @@ class PersistentVolumeClaimStatus {
 
   /// conditions is the current Condition of persistent volume claim.
   ///
-  /// If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+  /// If underlying persistent volume is being resized then the Condition will be set to 'Resizing'.
   conditions: Listing<PersistentVolumeClaimCondition>?
 
   /// ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
@@ -145,7 +145,7 @@ class PersistentVolumeClaimStatus {
 class PersistentVolumeClaimCondition {
   /// reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition.
   ///
-  /// If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+  /// If it reports "Resizing" that means the underlying persistent volume is being resized.
   reason: String?
 
   /// lastTransitionTime is the time the condition transitioned from one status to another.

--- a/generated-package/api/core/v1/PersistentVolumeClaimSpec.pkl
+++ b/generated-package/api/core/v1/PersistentVolumeClaimSpec.pkl
@@ -58,7 +58,7 @@ volumeName: String?
 /// An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
 /// If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists.
 /// If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists.
-/// More info: <https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass> (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+/// More info: <https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/> (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
 @K8sVersion { introducedIn = "1.29" }
 volumeAttributesClassName: String?
 

--- a/generated-package/api/core/v1/Pod.pkl
+++ b/generated-package/api/core/v1/Pod.pkl
@@ -231,6 +231,10 @@ class ContainerStatus {
   ///
   /// This field is not populated if the container is still running and RestartCount is 0.
   lastState: ContainerState?
+
+  /// Status of volume mounts.
+  @K8sVersion { introducedIn = "1.30" }
+  volumeMounts: Listing<VolumeMountStatus>?
 }
 
 /// ContainerState holds a possible state of container.
@@ -285,6 +289,23 @@ class ContainerStateTerminated {
 
   /// Time at which the container last terminated
   finishedAt: Time?
+}
+
+/// VolumeMountStatus shows status of volume mounts.
+class VolumeMountStatus {
+  /// MountPath corresponds to the original VolumeMount.
+  mountPath: String
+
+  /// Name corresponds to the name of the original VolumeMount.
+  name: String
+
+  /// ReadOnly corresponds to the original VolumeMount.
+  readOnly: Boolean?
+
+  /// RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts).
+  ///
+  /// An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled, depending on the mount result.
+  recursiveReadOnly: String?
 }
 
 /// PodIP represents a single IP address allocated to the pod.

--- a/generated-package/api/core/v1/PodSpec.pkl
+++ b/generated-package/api/core/v1/PodSpec.pkl
@@ -22,6 +22,7 @@ extends ".../K8sObject.pkl"
 
 import ".../api/core/v1/LocalObjectReference.pkl"
 import ".../api/core/v1/SELinuxOptions.pkl"
+import ".../api/core/v1/AppArmorProfile.pkl"
 import ".../api/core/v1/SeccompProfile.pkl" as SeccompProfileModule
 import ".../api/core/v1/WindowsSecurityContextOptions.pkl" as WindowsSecurityContextOptionsModule
 import ".../api/core/v1/Toleration.pkl"
@@ -101,8 +102,6 @@ imagePullSecrets: Listing<LocalObjectReference>?
 priorityClassName: String?
 
 /// HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
-///
-/// This is only valid for non-hostNetwork pods.
 hostAliases: Listing<HostAlias>(hostNetwork != true)?
 
 /// SecurityContext holds pod-level security attributes and common container settings.
@@ -144,8 +143,6 @@ automountServiceAccountToken: Boolean?
 /// If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.
 /// 
 /// SchedulingGates can only be set at pod creation time, and be removed only afterwards.
-/// 
-/// This is a beta feature enabled by the PodSchedulingReadiness feature gate.
 @K8sVersion { introducedIn = "1.26" }
 schedulingGates: Listing<PodSchedulingGate>?
 
@@ -165,7 +162,7 @@ activeDeadlineSeconds: Int?
 /// 
 /// If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
 /// 
-/// If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+/// If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
 @K8sVersion { introducedIn = "1.23" }
 os: PodOS?
 
@@ -214,7 +211,7 @@ volumes: Listing<Volume>?
 /// In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
 ephemeralContainers: Listing<EphemeralContainerModule>?
 
-/// DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+/// DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
 ///
 /// Deprecated: Use serviceAccountName instead.
 @Deprecated
@@ -361,6 +358,12 @@ class PodSecurityContext {
   /// If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
   /// Note that this field cannot be set when spec.os.name is windows.
   seLinuxOptions: SELinuxOptions?
+
+  /// appArmorProfile is the AppArmor options to use by the containers in this pod.
+  ///
+  /// Note that this field cannot be set when spec.os.name is windows.
+  @K8sVersion { introducedIn = "1.30" }
+  appArmorProfile: AppArmorProfile?
 
   /// A special supplemental group that applies to all containers in a pod.
   ///
@@ -518,8 +521,6 @@ class TopologySpreadConstraint {
   /// 
   /// For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
   /// In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
-  /// 
-  /// This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
   @K8sVersion { introducedIn = "1.24" }
   minDomains: Int32?
 
@@ -832,22 +833,22 @@ class PodAffinityTerm {
 
   /// MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
   ///
-  /// The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity.
+  /// The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity.
   /// Keys that don't exist in the incoming pod labels will be ignored.
   /// The default value is empty.
-  /// The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-  /// Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+  /// The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+  /// Also, matchLabelKeys cannot be set when labelSelector isn't set.
   /// This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
   @K8sVersion { introducedIn = "1.29" }
   matchLabelKeys: Listing<String>?
 
   /// MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration.
   ///
-  /// The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity.
+  /// The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity.
   /// Keys that don't exist in the incoming pod labels will be ignored.
   /// The default value is empty.
-  /// The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-  /// Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+  /// The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+  /// Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
   /// This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
   @K8sVersion { introducedIn = "1.29" }
   mismatchLabelKeys: Listing<String>?

--- a/generated-package/api/core/v1/SecurityContext.pkl
+++ b/generated-package/api/core/v1/SecurityContext.pkl
@@ -24,6 +24,7 @@ module k8s.api.core.v1.SecurityContext
 extends ".../K8sObject.pkl"
 
 import ".../api/core/v1/SELinuxOptions.pkl"
+import ".../api/core/v1/AppArmorProfile.pkl"
 import ".../api/core/v1/SeccompProfile.pkl"
 import ".../api/core/v1/WindowsSecurityContextOptions.pkl"
 
@@ -55,6 +56,13 @@ capabilities: Capabilities?
 /// If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
 /// Note that this field cannot be set when spec.os.name is windows.
 seLinuxOptions: SELinuxOptions?
+
+/// appArmorProfile is the AppArmor options to use by this container.
+///
+/// If set, this profile overrides the pod's appArmorProfile.
+/// Note that this field cannot be set when spec.os.name is windows.
+@K8sVersion { introducedIn = "1.30" }
+appArmorProfile: AppArmorProfile?
 
 /// The seccomp options to use by this container.
 ///

--- a/generated-package/api/core/v1/Service.pkl
+++ b/generated-package/api/core/v1/Service.pkl
@@ -102,6 +102,14 @@ class ServiceSpec {
   /// More info: <https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies>
   sessionAffinity: String?
 
+  /// TrafficDistribution offers a way to express preferences for how traffic is distributed to Service endpoints.
+  ///
+  /// Implementations can use this field as a hint, but are not required to guarantee strict adherence.
+  /// If the field is not set, the implementation will apply its default routing strategy.
+  /// If set to "PreferClose", implementations should prioritize endpoints that are topologically close (e.g., same zone).
+  @K8sVersion { introducedIn = "1.30" }
+  trafficDistribution: String?
+
   /// allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.
   ///
   /// Default is "true".

--- a/generated-package/api/core/v1/Volume.pkl
+++ b/generated-package/api/core/v1/Volume.pkl
@@ -376,7 +376,7 @@ class DownwardAPIVolumeFile {
   /// Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
   resourceFieldRef: ResourceFieldSelector?
 
-  /// Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+  /// Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.
   fieldRef: ObjectFieldSelector?
 }
 

--- a/generated-package/api/core/v1/VolumeMount.pkl
+++ b/generated-package/api/core/v1/VolumeMount.pkl
@@ -29,6 +29,7 @@ mountPath: String
 ///
 /// When not set, MountPropagationNone is used.
 /// This field is beta in 1.10.
+/// When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
 mountPropagation: String?
 
 /// This must match the Name of a Volume.
@@ -43,6 +44,21 @@ readOnly: Boolean?
 ///
 /// Defaults to "" (volume's root).
 subPath: String?
+
+/// RecursiveReadOnly specifies whether read-only mounts should be handled recursively.
+///
+/// 
+/// If ReadOnly is false, this field has no meaning and must be unspecified.
+/// 
+/// If ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.
+/// If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.
+/// If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.
+/// 
+/// If this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).
+/// 
+/// If this field is not specified, it is treated as an equivalent of Disabled.
+@K8sVersion { introducedIn = "1.30" }
+recursiveReadOnly: String?
 
 /// Expanded path within the volume from which the container's volume should be mounted.
 ///

--- a/generated-package/api/networking/v1alpha1/IPAddress.pkl
+++ b/generated-package/api/networking/v1alpha1/IPAddress.pkl
@@ -47,16 +47,16 @@ class IPAddressSpec {
   /// ParentRef references the resource that an IPAddress is attached to.
   ///
   /// An IPAddress must reference a parent object.
-  parentRef: ParentReference?
+  parentRef: ParentReference
 }
 
 /// ParentReference describes a reference to a parent object.
 class ParentReference {
   /// Resource is the resource of the object being referenced.
-  resource: String?
+  resource: String
 
   /// Name is the name of the object being referenced.
-  name: String?
+  name: String
 
   /// Namespace is the namespace of the object being referenced.
   namespace: String?

--- a/generated-package/api/resource/v1alpha2/ResourceClaim.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClaim.pkl
@@ -111,6 +111,40 @@ class ResourceHandle {
   ///
   /// This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.
   driverName: String?
+
+  /// If StructuredData is set, then it needs to be used instead of Data.
+  @K8sVersion { introducedIn = "1.30" }
+  structuredData: StructuredResourceHandle?
+}
+
+/// StructuredResourceHandle is the in-tree representation of the allocation result.
+class StructuredResourceHandle {
+  /// NodeName is the name of the node providing the necessary resources if the resources are local to a node.
+  nodeName: String?
+
+  /// VendorClassParameters are the per-claim configuration parameters from the resource class at the time that the claim was allocated.
+  vendorClassParameters: RawExtension?
+
+  /// Results lists all allocated driver resources.
+  results: Listing<DriverAllocationResult>
+
+  /// VendorClaimParameters are the per-claim configuration parameters from the resource claim parameters at the time that the claim was allocated.
+  vendorClaimParameters: RawExtension?
+}
+
+/// DriverAllocationResult contains vendor parameters and the allocation result for one request.
+class DriverAllocationResult {
+  /// NamedResources describes the allocation result when using the named resources model.
+  namedResources: NamedResourcesAllocationResult?
+
+  /// VendorRequestParameters are the per-request configuration parameters from the time that the claim was allocated.
+  vendorRequestParameters: RawExtension?
+}
+
+/// NamedResourcesAllocationResult is used in AllocationResultModel.
+class NamedResourcesAllocationResult {
+  /// Name is the name of the selected resource instance.
+  name: String
 }
 
 /// ResourceClaimConsumerReference contains enough information to let you locate the consumer of a ResourceClaim.

--- a/generated-package/api/resource/v1alpha2/ResourceClaimParameters.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClaimParameters.pkl
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ResourceClaimParameters defines resource requests for a ResourceClaim in an in-tree format understood by Kubernetes.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.resource.v1alpha2.ResourceClaimParameters
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl"
+
+fixed apiVersion: "resource.k8s.io/v1alpha2"
+
+fixed kind: "ResourceClaimParameters"
+
+/// Shareable indicates whether the allocated claim is meant to be shareable by multiple consumers at the same time.
+shareable: Boolean?
+
+/// Standard object metadata
+metadata: ObjectMeta?
+
+/// DriverRequests describes all resources that are needed for the allocated claim.
+///
+/// A single claim may use resources coming from different drivers.
+/// For each driver, this array has at most one entry which then may have one or more per-driver requests.
+/// 
+/// May be empty, in which case the claim can always be allocated.
+driverRequests: Listing<DriverRequests>?
+
+/// If this object was created from some other resource, then this links back to that resource.
+///
+/// This field is used to find the in-tree representation of the claim parameters when the parameter reference of the claim refers to some unknown type.
+generatedFrom: ResourceClaimParametersReference?
+
+/// DriverRequests describes all resources that are needed from one particular driver.
+class DriverRequests {
+  /// VendorParameters are arbitrary setup parameters for all requests of the claim.
+  ///
+  /// They are ignored while allocating the claim.
+  vendorParameters: RawExtension?
+
+  /// DriverName is the name used by the DRA driver kubelet plugin.
+  driverName: String?
+
+  /// Requests describes all resources that are needed from the driver.
+  requests: Listing<ResourceRequest>?
+}
+
+/// ResourceRequest is a request for resources from one particular driver.
+class ResourceRequest {
+  /// VendorParameters are arbitrary setup parameters for the requested resource.
+  ///
+  /// They are ignored while allocating a claim.
+  vendorParameters: RawExtension?
+
+  /// NamedResources describes a request for resources with the named resources model.
+  namedResources: NamedResourcesRequest?
+}
+
+/// NamedResourcesRequest is used in ResourceRequestModel.
+class NamedResourcesRequest {
+  /// Selector is a CEL expression which must evaluate to true if a resource instance is suitable.
+  ///
+  /// The language is as defined in <https://kubernetes.io/docs/reference/using-api/cel/>
+  /// 
+  /// In addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation.
+  /// For example:
+  /// 
+  ///    attributes.quantity["a"].isGreaterThan(quantity("0")) &&
+  ///    attributes.stringslice["b"].isSorted()
+  selector: String
+}
+

--- a/generated-package/api/resource/v1alpha2/ResourceClaimParametersList.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClaimParametersList.pkl
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ResourceClaimParametersList is a collection of ResourceClaimParameters.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.resource.v1alpha2.ResourceClaimParametersList
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ListMeta.pkl"
+import ".../api/resource/v1alpha2/ResourceClaimParameters.pkl"
+
+fixed apiVersion: "resource.k8s.io/v1alpha2"
+
+fixed kind: "ResourceClaimParametersList"
+
+/// Standard list metadata
+metadata: ListMeta?
+
+/// Items is the list of node resource capacity objects.
+items: Listing<ResourceClaimParameters>
+

--- a/generated-package/api/resource/v1alpha2/ResourceClaimParametersReference.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClaimParametersReference.pkl
@@ -14,26 +14,26 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-/// ResourceClaimSpec defines how a resource is to be allocated.
+/// ResourceClaimParametersReference contains enough information to let you locate the parameters for a ResourceClaim.
+///
+/// The object must be in the same namespace as the ResourceClaim.
 @K8sVersion { introducedIn = "1.27" }
 @ModuleInfo { minPklVersion = "0.25.0" }
-module k8s.api.resource.v1alpha2.ResourceClaimSpec
+module k8s.api.resource.v1alpha2.ResourceClaimParametersReference
 
 extends ".../K8sObject.pkl"
 
-import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl"
-
-/// Allocation can start immediately or when a Pod wants to use the resource.
+/// APIGroup is the group for the resource being referenced.
 ///
-/// "WaitForFirstConsumer" is the default.
-allocationMode: String?
+/// It is empty for the core API.
+/// This matches the group in the APIVersion that is used when creating the resources.
+apiGroup: String?
 
-/// ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
-resourceClassName: String
-
-/// ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
+/// Kind is the type of resource being referenced.
 ///
-/// 
-/// The object must be in the same namespace as the ResourceClaim.
-parametersRef: ResourceClaimParametersReference?
+/// This is the same value as in the parameter object's metadata, for example "ConfigMap".
+kind: String
+
+/// Name is the name of resource being referenced.
+name: String
 

--- a/generated-package/api/resource/v1alpha2/ResourceClaimSpec.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClaimSpec.pkl
@@ -21,7 +21,7 @@ module k8s.api.resource.v1alpha2.ResourceClaimSpec
 
 extends ".../K8sObject.pkl"
 
-import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl"
+import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl" as ResourceClaimParametersReferenceModule
 
 /// Allocation can start immediately or when a Pod wants to use the resource.
 ///
@@ -35,5 +35,8 @@ resourceClassName: String
 ///
 /// 
 /// The object must be in the same namespace as the ResourceClaim.
-parametersRef: ResourceClaimParametersReference?
+parametersRef: ResourceClaimParametersReferenceModule?
+
+@Deprecated { message = "`ResourceClaimParametersReference` has been moved into its own module."; replaceWith = "ResourceClaimParametersReferenceModule" }
+typealias ResourceClaimParametersReference = ResourceClaimParametersReferenceModule
 

--- a/generated-package/api/resource/v1alpha2/ResourceClass.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClass.pkl
@@ -26,7 +26,7 @@ extends ".../K8sResource.pkl"
 
 import ".../api/core/v1/NodeSelector.pkl"
 import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
-import ".../api/resource/v1alpha2/ResourceClassParametersReference.pkl"
+import ".../api/resource/v1alpha2/ResourceClassParametersReference.pkl" as ResourceClassParametersReferenceModule
 
 fixed apiVersion: "resource.k8s.io/v1alpha2"
 
@@ -45,7 +45,7 @@ metadata: ObjectMeta?
 /// ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class.
 ///
 /// A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
-parametersRef: ResourceClassParametersReference?
+parametersRef: ResourceClassParametersReferenceModule?
 
 /// DriverName defines the name of the dynamic resource driver that is used for allocation of a ResourceClaim that uses this class.
 ///
@@ -56,4 +56,7 @@ driverName: String
 /// If and only if allocation of claims using this class is handled via structured parameters, then StructuredParameters must be set to true.
 @K8sVersion { introducedIn = "1.30" }
 structuredParameters: Boolean?
+
+@Deprecated { message = "`ResourceClassParametersReference` has been moved into its own module."; replaceWith = "ResourceClassParametersReferenceModule" }
+typealias ResourceClassParametersReference = ResourceClassParametersReferenceModule
 

--- a/generated-package/api/resource/v1alpha2/ResourceClass.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClass.pkl
@@ -26,6 +26,7 @@ extends ".../K8sResource.pkl"
 
 import ".../api/core/v1/NodeSelector.pkl"
 import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+import ".../api/resource/v1alpha2/ResourceClassParametersReference.pkl"
 
 fixed apiVersion: "resource.k8s.io/v1alpha2"
 
@@ -52,25 +53,7 @@ parametersRef: ResourceClassParametersReference?
 /// Resource drivers have a unique name in forward domain order (acme.example.com).
 driverName: String
 
-/// ResourceClassParametersReference contains enough information to let you locate the parameters for a ResourceClass.
-class ResourceClassParametersReference {
-  /// APIGroup is the group for the resource being referenced.
-  ///
-  /// It is empty for the core API.
-  /// This matches the group in the APIVersion that is used when creating the resources.
-  apiGroup: String?
-
-  /// Kind is the type of resource being referenced.
-  ///
-  /// This is the same value as in the parameter object's metadata.
-  kind: String
-
-  /// Name is the name of resource being referenced.
-  name: String
-
-  /// Namespace that contains the referenced resource.
-  ///
-  /// Must be empty for cluster-scoped resources and non-empty for namespaced resources.
-  namespace: String?
-}
+/// If and only if allocation of claims using this class is handled via structured parameters, then StructuredParameters must be set to true.
+@K8sVersion { introducedIn = "1.30" }
+structuredParameters: Boolean?
 

--- a/generated-package/api/resource/v1alpha2/ResourceClassParameters.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClassParameters.pkl
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ResourceClassParameters defines resource requests for a ResourceClass in an in-tree format understood by Kubernetes.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.resource.v1alpha2.ResourceClassParameters
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+import ".../api/resource/v1alpha2/ResourceClassParametersReference.pkl"
+
+fixed apiVersion: "resource.k8s.io/v1alpha2"
+
+fixed kind: "ResourceClassParameters"
+
+/// Standard object metadata
+metadata: ObjectMeta?
+
+/// VendorParameters are arbitrary setup parameters for all claims using this class.
+///
+/// They are ignored while allocating the claim.
+/// There must not be more than one entry per driver.
+vendorParameters: Listing<VendorParameters>?
+
+/// Filters describes additional contraints that must be met when using the class.
+filters: Listing<ResourceFilter>?
+
+/// If this object was created from some other resource, then this links back to that resource.
+///
+/// This field is used to find the in-tree representation of the class parameters when the parameter reference of the class refers to some unknown type.
+generatedFrom: ResourceClassParametersReference?
+
+/// VendorParameters are opaque parameters for one particular driver.
+class VendorParameters {
+  /// DriverName is the name used by the DRA driver kubelet plugin.
+  driverName: String?
+
+  /// Parameters can be arbitrary setup parameters.
+  ///
+  /// They are ignored while allocating a claim.
+  parameters: RawExtension?
+}
+
+/// ResourceFilter is a filter for resources from one particular driver.
+class ResourceFilter {
+  /// NamedResources describes a resource filter using the named resources model.
+  namedResources: NamedResourcesFilter?
+
+  /// DriverName is the name used by the DRA driver kubelet plugin.
+  driverName: String?
+}
+
+/// NamedResourcesFilter is used in ResourceFilterModel.
+class NamedResourcesFilter {
+  /// Selector is a CEL expression which must evaluate to true if a resource instance is suitable.
+  ///
+  /// The language is as defined in <https://kubernetes.io/docs/reference/using-api/cel/>
+  /// 
+  /// In addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation.
+  /// For example:
+  /// 
+  ///    attributes.quantity["a"].isGreaterThan(quantity("0")) &&
+  ///    attributes.stringslice["b"].isSorted()
+  selector: String
+}
+

--- a/generated-package/api/resource/v1alpha2/ResourceClassParametersList.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClassParametersList.pkl
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ResourceClassParametersList is a collection of ResourceClassParameters.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.resource.v1alpha2.ResourceClassParametersList
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ListMeta.pkl"
+import ".../api/resource/v1alpha2/ResourceClassParameters.pkl"
+
+fixed apiVersion: "resource.k8s.io/v1alpha2"
+
+fixed kind: "ResourceClassParametersList"
+
+/// Standard list metadata
+metadata: ListMeta?
+
+/// Items is the list of node resource capacity objects.
+items: Listing<ResourceClassParameters>
+

--- a/generated-package/api/resource/v1alpha2/ResourceClassParametersReference.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceClassParametersReference.pkl
@@ -14,26 +14,29 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-/// ResourceClaimSpec defines how a resource is to be allocated.
+/// ResourceClassParametersReference contains enough information to let you locate the parameters for a ResourceClass.
 @K8sVersion { introducedIn = "1.27" }
 @ModuleInfo { minPklVersion = "0.25.0" }
-module k8s.api.resource.v1alpha2.ResourceClaimSpec
+module k8s.api.resource.v1alpha2.ResourceClassParametersReference
 
 extends ".../K8sObject.pkl"
 
-import ".../api/resource/v1alpha2/ResourceClaimParametersReference.pkl"
-
-/// Allocation can start immediately or when a Pod wants to use the resource.
+/// APIGroup is the group for the resource being referenced.
 ///
-/// "WaitForFirstConsumer" is the default.
-allocationMode: String?
+/// It is empty for the core API.
+/// This matches the group in the APIVersion that is used when creating the resources.
+apiGroup: String?
 
-/// ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
-resourceClassName: String
-
-/// ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
+/// Kind is the type of resource being referenced.
 ///
-/// 
-/// The object must be in the same namespace as the ResourceClaim.
-parametersRef: ResourceClaimParametersReference?
+/// This is the same value as in the parameter object's metadata.
+kind: String
+
+/// Name is the name of resource being referenced.
+name: String
+
+/// Namespace that contains the referenced resource.
+///
+/// Must be empty for cluster-scoped resources and non-empty for namespaced resources.
+namespace: String?
 

--- a/generated-package/api/resource/v1alpha2/ResourceSlice.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceSlice.pkl
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ResourceSlice provides information about available resources on individual nodes.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.resource.v1alpha2.ResourceSlice
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "resource.k8s.io/v1alpha2"
+
+fixed kind: "ResourceSlice"
+
+/// NodeName identifies the node which provides the resources if they are local to a node.
+///
+/// 
+/// A field selector can be used to list only ResourceSlice objects with a certain node name.
+nodeName: String?
+
+/// Standard object metadata
+metadata: ObjectMeta?
+
+/// NamedResources describes available resources using the named resources model.
+namedResources: NamedResourcesResources?
+
+/// DriverName identifies the DRA driver providing the capacity information.
+///
+/// A field selector can be used to list only ResourceSlice objects with a certain driver name.
+driverName: String
+
+/// NamedResourcesResources is used in ResourceModel.
+class NamedResourcesResources {
+  /// The list of all individual resources instances currently available.
+  instances: Listing<NamedResourcesInstance>
+}
+
+/// NamedResourcesInstance represents one individual hardware instance that can be selected based on its attributes.
+class NamedResourcesInstance {
+  /// Name is unique identifier among all resource instances managed by the driver on the node.
+  ///
+  /// It must be a DNS subdomain.
+  name: String
+
+  /// Attributes defines the attributes of this resource instance.
+  ///
+  /// The name of each attribute must be unique.
+  attributes: Listing<NamedResourcesAttribute>?
+}
+
+/// NamedResourcesAttribute is a combination of an attribute name and its value.
+class NamedResourcesAttribute {
+  /// QuantityValue is a quantity.
+  quantity: Quantity?
+
+  /// BoolValue is a true/false value.
+  bool: Boolean?
+
+  /// StringValue is a string.
+  string: String?
+
+  /// Name is unique identifier among all resource instances managed by the driver on the node.
+  ///
+  /// It must be a DNS subdomain.
+  name: String
+
+  /// IntSliceValue is an array of 64-bit integers.
+  intSlice: NamedResourcesIntSlice?
+
+  /// StringSliceValue is an array of strings.
+  stringSlice: NamedResourcesStringSlice?
+
+  /// VersionValue is a semantic version according to semver.org spec 2.0.0.
+  version: String?
+
+  /// IntValue is a 64-bit integer.
+  int: Int?
+}
+
+/// NamedResourcesIntSlice contains a slice of 64-bit integers.
+class NamedResourcesIntSlice {
+  /// Ints is the slice of 64-bit integers.
+  ints: Listing<Int>
+}
+
+/// NamedResourcesStringSlice contains a slice of strings.
+class NamedResourcesStringSlice {
+  /// Strings is the slice of strings.
+  strings: Listing<String>
+}
+

--- a/generated-package/api/resource/v1alpha2/ResourceSliceList.pkl
+++ b/generated-package/api/resource/v1alpha2/ResourceSliceList.pkl
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// ResourceSliceList is a collection of ResourceSlices.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.resource.v1alpha2.ResourceSliceList
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ListMeta.pkl"
+import ".../api/resource/v1alpha2/ResourceSlice.pkl"
+
+fixed apiVersion: "resource.k8s.io/v1alpha2"
+
+fixed kind: "ResourceSliceList"
+
+/// Standard list metadata
+metadata: ListMeta?
+
+/// Items is the list of node resource capacity objects.
+items: Listing<ResourceSlice>
+

--- a/generated-package/api/storage/v1/CSIDriver.pkl
+++ b/generated-package/api/storage/v1/CSIDriver.pkl
@@ -46,7 +46,7 @@ class CSIDriverSpec {
   ///
   /// Refer to the specific FSGroupPolicy values for additional details.
   /// 
-  /// This field is immutable.
+  /// This field was immutable in Kubernetes < 1.29 and now is mutable.
   /// 
   /// Defaults to ReadWriteOnceWithFSType, which will examine each volume to determine if Kubernetes should modify ownership and permissions of the volume.
   /// With the default policy the defined fsGroup will only be applied if a fstype is defined and the volume's access mode contains ReadWriteOnce.
@@ -130,7 +130,7 @@ class CSIDriverSpec {
   /// Other drivers can leave pod info disabled and/or ignore this field.
   /// As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
   /// 
-  /// This field is immutable.
+  /// This field was immutable in Kubernetes < 1.29 and now is mutable.
   podInfoOnMount: Boolean?
 
   /// seLinuxMount specifies if the CSI driver supports "-o context" mount option.

--- a/generated-package/api/storagemigration/v1alpha1/StorageVersionMigration.pkl
+++ b/generated-package/api/storagemigration/v1alpha1/StorageVersionMigration.pkl
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// StorageVersionMigration represents a migration of stored data to the latest storage version.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.storagemigration.v1alpha1.StorageVersionMigration
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
+
+fixed apiVersion: "storagemigration.k8s.io/v1alpha1"
+
+fixed kind: "StorageVersionMigration"
+
+/// Standard object metadata.
+///
+/// More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>
+metadata: ObjectMeta?
+
+/// Specification of the migration.
+spec: StorageVersionMigrationSpec?
+
+/// Status of the migration.
+status: StorageVersionMigrationStatus?
+
+/// Spec of the storage version migration.
+class StorageVersionMigrationSpec {
+  /// The token used in the list options to get the next chunk of objects to migrate.
+  ///
+  /// When the .status.conditions indicates the migration is "Running", users can use this token to check the progress of the migration.
+  continueToken: String?
+
+  /// The resource that is being migrated.
+  ///
+  /// The migrator sends requests to the endpoint serving the resource.
+  /// Immutable.
+  resource: GroupVersionResource
+}
+
+/// The names of the group, the version, and the resource.
+class GroupVersionResource {
+  /// The name of the resource.
+  resource: String?
+
+  /// The name of the version.
+  version: String?
+
+  /// The name of the group.
+  group: String?
+}
+
+/// Status of the storage version migration.
+class StorageVersionMigrationStatus {
+  /// ResourceVersion to compare with the GC cache for performing the migration.
+  ///
+  /// This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.
+  resourceVersion: String?
+
+  /// The latest available observations of the migration's current state.
+  conditions: Listing<MigrationCondition>?
+}
+
+/// Describes the state of a migration at a certain point.
+class MigrationCondition {
+  /// The reason for the condition's last transition.
+  reason: String?
+
+  /// A human readable message indicating details about the transition.
+  message: String?
+
+  /// Type of the condition.
+  type: String
+
+  /// The last time this condition was updated.
+  lastUpdateTime: Time?
+
+  /// Status of the condition, one of True, False, Unknown.
+  status: String
+}
+

--- a/generated-package/api/storagemigration/v1alpha1/StorageVersionMigrationList.pkl
+++ b/generated-package/api/storagemigration/v1alpha1/StorageVersionMigrationList.pkl
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// StorageVersionMigrationList is a collection of storage version migrations.
+@K8sVersion { introducedIn = "1.30" }
+@ModuleInfo { minPklVersion = "0.25.0" }
+open module k8s.api.storagemigration.v1alpha1.StorageVersionMigrationList
+
+extends ".../K8sResource.pkl"
+
+import ".../apimachinery/pkg/apis/meta/v1/ListMeta.pkl"
+import ".../api/storagemigration/v1alpha1/StorageVersionMigration.pkl"
+
+fixed apiVersion: "storagemigration.k8s.io/v1alpha1"
+
+fixed kind: "StorageVersionMigrationList"
+
+/// Standard list metadata More info: <https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata>
+metadata: ListMeta?
+
+/// Items is the list of StorageVersionMigration
+items: Listing<StorageVersionMigration>
+

--- a/generated-package/apiextensions-apiserver/pkg/apis/apiextensions/v1/CustomResourceDefinition.pkl
+++ b/generated-package/apiextensions-apiserver/pkg/apis/apiextensions/v1/CustomResourceDefinition.pkl
@@ -149,6 +149,13 @@ class CustomResourceDefinitionVersion {
   /// See <https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables> for details.
   /// If no columns are specified, a single column displaying the age of the custom resource is used.
   additionalPrinterColumns: Listing<CustomResourceColumnDefinition>?
+
+  /// selectableFields specifies paths to fields that may be used as field selectors.
+  ///
+  /// A maximum of 8 selectable fields are allowed.
+  /// See <https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors>
+  @K8sVersion { introducedIn = "1.30" }
+  selectableFields: Listing<SelectableField>?
 }
 
 /// CustomResourceValidation is a list of validation methods for CustomResources.
@@ -520,6 +527,19 @@ class CustomResourceColumnDefinition {
   ///
   /// See <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types> for details.
   type: String
+}
+
+/// SelectableField specifies the JSON path of a field that may be used with field selectors.
+class SelectableField {
+  /// jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value.
+  ///
+  /// Only JSON paths without the array notation are allowed.
+  /// Must point to a field of type string, boolean or integer.
+  /// Types with enum values and strings with formats are allowed.
+  /// If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string.
+  /// Must not point to metdata fields.
+  /// Required.
+  jsonPath: String
 }
 
 /// CustomResourceConversion describes how to convert different versions of a CR.

--- a/generated-package/k8sSchema.pkl
+++ b/generated-package/k8sSchema.pkl
@@ -393,6 +393,12 @@ resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
     ["resource.k8s.io/v1alpha1"] = import("api/resource/v1alpha1/ResourceClaimList.pkl")
     ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceClaimList.pkl")
   }
+  ["ResourceClaimParameters"] {
+    ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceClaimParameters.pkl")
+  }
+  ["ResourceClaimParametersList"] {
+    ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceClaimParametersList.pkl")
+  }
   ["ResourceClaimTemplate"] {
     ["resource.k8s.io/v1alpha1"] = import("api/resource/v1alpha1/ResourceClaimTemplate.pkl")
     ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceClaimTemplate.pkl")
@@ -409,11 +415,23 @@ resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
     ["resource.k8s.io/v1alpha1"] = import("api/resource/v1alpha1/ResourceClassList.pkl")
     ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceClassList.pkl")
   }
+  ["ResourceClassParameters"] {
+    ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceClassParameters.pkl")
+  }
+  ["ResourceClassParametersList"] {
+    ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceClassParametersList.pkl")
+  }
   ["ResourceQuota"] {
     ["v1"] = import("api/core/v1/ResourceQuota.pkl")
   }
   ["ResourceQuotaList"] {
     ["v1"] = import("api/core/v1/ResourceQuotaList.pkl")
+  }
+  ["ResourceSlice"] {
+    ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceSlice.pkl")
+  }
+  ["ResourceSliceList"] {
+    ["resource.k8s.io/v1alpha2"] = import("api/resource/v1alpha2/ResourceSliceList.pkl")
   }
   ["Role"] {
     ["rbac.authorization.k8s.io/v1"] = import("api/rbac/v1/Role.pkl")
@@ -508,6 +526,12 @@ resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
   ["StorageVersionList"] {
     ["internal.apiserver.k8s.io/v1alpha1"] = import("api/apiserverinternal/v1alpha1/StorageVersionList.pkl")
   }
+  ["StorageVersionMigration"] {
+    ["storagemigration.k8s.io/v1alpha1"] = import("api/storagemigration/v1alpha1/StorageVersionMigration.pkl")
+  }
+  ["StorageVersionMigrationList"] {
+    ["storagemigration.k8s.io/v1alpha1"] = import("api/storagemigration/v1alpha1/StorageVersionMigrationList.pkl")
+  }
   ["SubjectAccessReview"] {
     ["authorization.k8s.io/v1"] = import("api/authorization/v1/SubjectAccessReview.pkl")
     ["authorization.k8s.io/v1beta1"] = import("api/authorization/v1beta1/SubjectAccessReview.pkl")
@@ -522,18 +546,22 @@ resourceTemplates: Mapping<String, Mapping<String, unknown>> = new {
   ["ValidatingAdmissionPolicy"] {
     ["admissionregistration.k8s.io/v1alpha1"] = import("api/admissionregistration/v1alpha1/ValidatingAdmissionPolicy.pkl")
     ["admissionregistration.k8s.io/v1beta1"] = import("api/admissionregistration/v1beta1/ValidatingAdmissionPolicy.pkl")
+    ["admissionregistration.k8s.io/v1"] = import("api/admissionregistration/v1/ValidatingAdmissionPolicy.pkl")
   }
   ["ValidatingAdmissionPolicyBinding"] {
     ["admissionregistration.k8s.io/v1alpha1"] = import("api/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBinding.pkl")
     ["admissionregistration.k8s.io/v1beta1"] = import("api/admissionregistration/v1beta1/ValidatingAdmissionPolicyBinding.pkl")
+    ["admissionregistration.k8s.io/v1"] = import("api/admissionregistration/v1/ValidatingAdmissionPolicyBinding.pkl")
   }
   ["ValidatingAdmissionPolicyBindingList"] {
     ["admissionregistration.k8s.io/v1alpha1"] = import("api/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingList.pkl")
     ["admissionregistration.k8s.io/v1beta1"] = import("api/admissionregistration/v1beta1/ValidatingAdmissionPolicyBindingList.pkl")
+    ["admissionregistration.k8s.io/v1"] = import("api/admissionregistration/v1/ValidatingAdmissionPolicyBindingList.pkl")
   }
   ["ValidatingAdmissionPolicyList"] {
     ["admissionregistration.k8s.io/v1alpha1"] = import("api/admissionregistration/v1alpha1/ValidatingAdmissionPolicyList.pkl")
     ["admissionregistration.k8s.io/v1beta1"] = import("api/admissionregistration/v1beta1/ValidatingAdmissionPolicyList.pkl")
+    ["admissionregistration.k8s.io/v1"] = import("api/admissionregistration/v1/ValidatingAdmissionPolicyList.pkl")
   }
   ["ValidatingWebhookConfiguration"] {
     ["admissionregistration.k8s.io/v1"] = import("api/admissionregistration/v1/ValidatingWebhookConfiguration.pkl")

--- a/src/main/kotlin/org/pkl/k8s/templates/Overrides.kt
+++ b/src/main/kotlin/org/pkl/k8s/templates/Overrides.kt
@@ -38,6 +38,8 @@ val movedTypes = listOf(
   Pair("api.core.v1.PodSpec", "ContainerPort") to "api.core.v1.ContainerPort",
   Pair("api.core.v1.PodSpec", "Lifecycle") to "api.core.v1.Lifecycle",
   Pair("api.core.v1.PodSpec", "Handler") to "api.core.v1.Handler",
+  Pair("api.resource.v1alpha2.ResourceClaimSpec", "ResourceClaimParametersReference") to "api.resource.v1alpha2.ResourceClaimParametersReference",
+  Pair("api.resource.v1alpha2.ResourceClass", "ResourceClassParametersReference") to "api.resource.v1alpha2.ResourceClassParametersReference"
 )
 
 /**


### PR DESCRIPTION
Updates the `k8sVersions` list in the `build.gradle.kts` to include k8s 1.30. Does this need to bump the pklPackageVersion?

As an aside, I was surprised to see the lengthy list of k8s versions supported by this repo. Are there plans to trim the supported k8s versions as support for new versions is added?